### PR TITLE
Fix pyproject.toml 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Xircuits component library for Spark!"
 authors = [{ name = "XpressAI", email = "eduardo@xpress.ai" }]
 license = "Apache-2.0"
-readme = "readme.md"
+readme = "README.md"
 repository = "https://github.com/XpressAI/xai-spark"
 keywords = ["xircuits", "spark", "data processing", "big data", "data analysis", "streaming"]
 


### PR DESCRIPTION
# Description

This PR fixes metadata issues in the `pyproject.toml` of **xai-spark**:
- Corrected `readme` casing to `README.md`.
- Verified `default_example_path` points to a valid example
